### PR TITLE
(DAL) Added option to use sat-solver on guards

### DIFF
--- a/eclipse/plugins/net.sf.orcc.backends/plugin.xml
+++ b/eclipse/plugins/net.sf.orcc.backends/plugin.xml
@@ -63,6 +63,9 @@
          <option
                id="net.sf.orcc.backends.c.dal.outputBuffering">
          </option>
+         <option
+               id="net.sf.orcc.backends.c.dal.checkGuards">
+         </option>
       </backend>
       <backend
             class="net.sf.orcc.backends.c.hmpp.HMPPBackend"
@@ -406,6 +409,13 @@
                description="Perform sample buffering on actor outputs"
                id="net.sf.orcc.backends.c.dal.outputBuffering"
                name="Output buffering">
+            <checkBox></checkBox>
+         </option>
+         <option
+               defaultValue="false"
+               description="Check actors action guards to better identify non-determinism"
+               id="net.sf.orcc.backends.c.dal.checkGuards"
+               name="Check Guards">
             <checkBox></checkBox>
          </option>
          <option

--- a/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/dal/DALBackend.java
+++ b/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/dal/DALBackend.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  * Distributed Application Layer
  * 
  * @author Jani Boutellier
+ * @author James Guthrie
  * 
  * Based on Orcc C backend
  */
@@ -33,6 +34,7 @@ public class DALBackend extends CBackend {
 	protected String srcPath;
 	protected boolean outputBuffering;
 	protected boolean inputBuffering;
+	protected boolean checkGuards;
 
 	@Override
 	protected void doInitializeOptions() {
@@ -41,8 +43,11 @@ public class DALBackend extends CBackend {
 				false);
 		outputBuffering = getAttribute("net.sf.orcc.backends.c.dal.outputBuffering",
 				false);
+		checkGuards = getAttribute("net.sf.orcc.backends.c.dal.checkGuards",
+		        false);
 	}
 	
+	@Override
 	protected void doTransformNetwork(Network network) {
 		OrccLogger.traceln("Instantiating network...");
 		new Instantiator(false, fifoSize).doSwitch(network);
@@ -68,7 +73,7 @@ public class DALBackend extends CBackend {
 
 		new ArgumentEvaluator().doSwitch(network);
 		
-		KPNValidator validator = new KPNValidator();
+		KPNValidator validator = new KPNValidator(checkGuards);
 		validator.validate(network);
 		validator.analyzeInputs(network);
 		validator.analyzeOutputs(network);

--- a/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/dal/KPNValidator.java
+++ b/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/dal/KPNValidator.java
@@ -3,7 +3,9 @@ package net.sf.orcc.backends.c.dal;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.orcc.OrccRuntimeException;
 import net.sf.orcc.graph.Edge;
+import net.sf.orcc.tools.classifier.GuardSatChecker;
 import net.sf.orcc.util.OrccLogger;
 import net.sf.orcc.df.Actor;
 import net.sf.orcc.df.Action;
@@ -18,9 +20,20 @@ import net.sf.orcc.df.Network;
  * of a network.
  * 
  * @author Jani Boutellier
+ * @author James Guthrie
  * 
  */
 public class KPNValidator {
+
+	private boolean checkGuards;
+
+	public KPNValidator(){
+		this.checkGuards = false;
+	}
+
+	public KPNValidator(boolean checkGuards){
+		this.checkGuards = checkGuards;
+	}
 
 	public void validate(Network network) {
 		for (Actor actor : network.getAllActors()) {
@@ -115,8 +128,19 @@ public class KPNValidator {
 							actor.addAttribute("variableInputPattern");
 						}
 					} else {
-						OrccLogger.warnln("(" + actor.getName() + ") action '" + firstAction.getName() + "' reads port '"  + port.getName() +
-								"'\n but action '"+ secondAction.getName() + "' does not. Application may deadlock.");
+						boolean sat = true;
+						if (this.checkGuards) {
+							try {
+								GuardSatChecker checker = new GuardSatChecker(actor);
+								sat = checker.checkSat(firstAction, secondAction);
+							} catch(OrccRuntimeException e){
+								OrccLogger.warnln("Satisfiability check failed: '" + e.getMessage() + "'");
+							}
+						}
+						if (sat) {
+							OrccLogger.warnln("(" + actor.getName() + ") action '" + firstAction.getName() + "' reads port '"  + port.getName() +
+									"'\n but action '"+ secondAction.getName() + "' does not. Application may deadlock.");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Using the satisfiability solver on the action's guards allows us to
reduce the number of false positives that are produced when analysing
actors for non-deterministic (deadlock-causing) behaviour.
