### PR TITLE
Replace fseek+fwrite with putc. fixes orcc/orcc#115

### DIFF
--- a/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/writer.c
+++ b/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/writer.c
@@ -29,6 +29,7 @@
 
 // Author : Endri Bezati (endri.bezati@epfl.ch)
 // Author : Damien de Saint Jorre
+// Author : Rob Stewart (R.Stewart@hw.ac.uk)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,6 +41,13 @@
 #include "options.h"
 
 FILE *F = NULL;
+
+/*
+Rob Stewart: Now that `cnt` is not used beyond the fix to
+             https://github.com/orcc/orcc/issues/115 ,
+             it may be a candidate for obsolescence; it is
+             only used in `writer_closeAndQuit(..)`.
+*/
 static int cnt = 0;
 static char stop = 0;
 
@@ -66,9 +74,7 @@ void Writer_init() {
 }
 
 void Writer_write(u8 byte){
-
-    fseek(F,sizeof(u8)*cnt,SEEK_SET);
-    fwrite(&byte,sizeof(u8),1,F);
+    putc(byte,F);
     cnt++;
 }
 


### PR DESCRIPTION
The `Writer_write(..)` native procedure uses fseek, which is
unnecessary and is demonstrably costly to runtimes of programs that
use the procedure frequently, as shown in
https://github.com/orcc/orcc/issues/115

This commit removes fseek, and also replaces fwrite with putc. putc
is 2.2x faster for a large number of bytes streamed into a file, one
byte at a time which is what `Writer_write(..)` is doing. This has
been benchmarked in
https://github.com/robstewart57/fwrite-fputc-benchmark
