### PR TITLE
Move variable declarations to fix old MSVC versions

### DIFF
--- a/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/framerate_sdl.c
+++ b/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/framerate_sdl.c
@@ -79,12 +79,13 @@ void fpsPrintInit_mapping() {
 
 void fpsPrintNewPicDecoded(void) {
     unsigned int endTime;
+    float relativeTime;
 
     numPicturesDecoded++;
     partialNumPicturesDecoded++;
     endTime = SDL_GetTicks();
 
-    float relativeTime = (endTime - relativeStartTime) / 1000.0f;
+    relativeTime = (endTime - relativeStartTime) / 1000.0f;
 
     if(relativeTime >= 5) {
         float framerate = (numPicturesDecoded - lastNumPic) / relativeTime;

--- a/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/native_util.c
+++ b/eclipse/plugins/net.sf.orcc.backends/runtime/C/libs/orcc-native/src/native_util.c
@@ -34,9 +34,10 @@
 
 
 int fsize(FILE *fp) {
+    int sz;
     int prev=ftell(fp);
     fseek(fp, 0L, SEEK_END);
-    int sz=ftell(fp);
+    sz=ftell(fp);
     fseek(fp,prev,SEEK_SET); //go back to where we were
     return sz;
 }


### PR DESCRIPTION
Commit orcc/orcc@45276517f1586ba0137b43ad33fbfc1264f94ae6 introduced a
compilation error for old versions of Microsoft's MSVC. Deepayan
Bhowmik has identified two cases in orcc-native/ that violate C90
rules, where declarations follow statements in framerate_sdl.c and
native_util.c . See http://stackoverflow.com/a/13336213/1526266 .
Whilst this is fixed in the Microsoft Platform Toolset v120, this
commit provides a fix for older platform versions too.
