### PR TITLE
Replace "//" with "--" for VHDL comments in ActorNetworkTestBenchPrinter.xtend

### DIFF
--- a/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/hls/NetworkTestBenchPrinter.xtend
+++ b/eclipse/plugins/net.sf.orcc.backends/src/net/sf/orcc/backends/c/hls/NetworkTestBenchPrinter.xtend
@@ -92,7 +92,7 @@ class NetworkTestBenchPrinter extends net.sf.orcc.backends.c.NetworkPrinter {
 				«val connection = instance.incomingPortMap.get(port)»
 				«IF connection != null»
 					«IF connection.sourcePort == null»
-						«connection.castfifoNameWrite»_V_dout   : IN STD_LOGIC_VECTOR («connection.fifoTypeOut.sizeInBits - 1» downto 0); //fifotype
+						«connection.castfifoNameWrite»_V_dout   : IN STD_LOGIC_VECTOR («connection.fifoTypeOut.sizeInBits - 1» downto 0); -- fifotype
 						«connection.castfifoNameWrite»_V_empty_n : IN STD_LOGIC;
 						«connection.castfifoNameWrite»_V_read    : OUT STD_LOGIC;
 					«ENDIF»
@@ -101,7 +101,7 @@ class NetworkTestBenchPrinter extends net.sf.orcc.backends.c.NetworkPrinter {
 			«FOR portout : instance.getActor.outputs.filter[! native]»
 				«FOR connection : instance.outgoingPortMap.get(portout)»
 					«IF connection.targetPort == null»
-						«connection.castfifoNameRead»_V_din    : OUT STD_LOGIC_VECTOR («connection.fifoTypeOut.sizeInBits - 1» downto 0); //fifotype
+						«connection.castfifoNameRead»_V_din    : OUT STD_LOGIC_VECTOR («connection.fifoTypeOut.sizeInBits - 1» downto 0); -- fifotype
 						«connection.castfifoNameRead»_V_full_n : IN STD_LOGIC;
 						«connection.castfifoNameRead»_V_write  : OUT STD_LOGIC;
 					«ENDIF»				


### PR DESCRIPTION
FYI @mariem1010 . I believe the commenting syntax for VHDL is "--" ?
